### PR TITLE
Skill tag-based bonus application

### DIFF
--- a/InterknotCalculator/Classes/Calculator.cs
+++ b/InterknotCalculator/Classes/Calculator.cs
@@ -149,7 +149,7 @@ public class Calculator {
                DamageTakenMultiplier * StunMultiplier;
         
         return new() {
-            Name = $"{skill} { (scale == 0 && data.Scales.Count > 1 ? "" : scale + 1) }".Trim(),
+            Name = $"{skill} { (scale == 0 && data.Scales.Count == 1 ? "" : scale + 1) }".Trim(),
             Tag = data.Tag,
             Damage = total
         };

--- a/InterknotCalculator/Classes/Calculator.cs
+++ b/InterknotCalculator/Classes/Calculator.cs
@@ -150,7 +150,7 @@ public class Calculator {
         
         return new() {
             Name = $"{skill} {scale}",
-            Tag = SkillTag.AttributeAnomaly,
+            Tag = data.Tag,
             Damage = total
         };
     }

--- a/InterknotCalculator/Classes/Calculator.cs
+++ b/InterknotCalculator/Classes/Calculator.cs
@@ -125,7 +125,7 @@ public class Calculator {
         return levelFactor / (Math.Max(enemyDef * (1 - PenRatio) - Pen, 0) + levelFactor);
     }
 
-    private AgentAction GetStandardDamage(string skill, Index scale) {
+    private AgentAction GetStandardDamage(string skill, int scale) {
         var data = Agent.Skills[skill];
         var attribute = data.Scales[scale].Element ?? Agent.Element;
         var relatedAffixDmg = Helpers.GetRelatedAffixDmg(attribute);
@@ -149,7 +149,7 @@ public class Calculator {
                DamageTakenMultiplier * StunMultiplier;
         
         return new() {
-            Name = $"{skill} {scale}",
+            Name = $"{skill} { (scale == 0 && data.Scales.Count > 1 ? "" : scale + 1) }".Trim(),
             Tag = data.Tag,
             Damage = total
         };

--- a/InterknotCalculator/Classes/Extensions/StringExtensions.cs
+++ b/InterknotCalculator/Classes/Extensions/StringExtensions.cs
@@ -13,11 +13,13 @@ public static class StringExtensions {
         });
     }
 
-    private static EvaluationContext EvalContext { get; } = EvaluationContext.CreateDefault();
+    public static EvaluationContext EvalContext { get; } = EvaluationContext.CreateDefault();
+
+    public static SafeDictionary<string, double> Variables { get; set; } = new();
     
-    public static double EvaluateExpression(this string expression, Dictionary<string, double> variables) {
+    public static double EvaluateExpression(this string expression) {
         var eval = MathEvaluation.CompileExpression("tmp", 
-            expression.ProcessVariables(variables), CompilationMethod.ExpressionTree);
+            expression.ProcessVariables(Variables), CompilationMethod.ExpressionTree);
         return eval.Invoke(EvalContext);
     }
 }

--- a/InterknotCalculator/Classes/SerializerContext.cs
+++ b/InterknotCalculator/Classes/SerializerContext.cs
@@ -11,4 +11,5 @@ namespace InterknotCalculator.Classes;
 [JsonSerializable(typeof(DriveDiscSet))]
 [JsonSerializable(typeof(CalcRequest))]
 [JsonSerializable(typeof(CalcResult))]
+[JsonSerializable(typeof(Stat))]
 internal partial class SerializerContext : JsonSerializerContext { }

--- a/InterknotCalculator/Classes/SerializerContext.cs
+++ b/InterknotCalculator/Classes/SerializerContext.cs
@@ -9,7 +9,8 @@ namespace InterknotCalculator.Classes;
 [JsonSerializable(typeof(Agent))]
 [JsonSerializable(typeof(Weapon))]
 [JsonSerializable(typeof(DriveDiscSet))]
+[JsonSerializable(typeof(Stat))]
 [JsonSerializable(typeof(CalcRequest))]
 [JsonSerializable(typeof(CalcResult))]
-[JsonSerializable(typeof(Stat))]
+[JsonSerializable(typeof(AgentAction))]
 internal partial class SerializerContext : JsonSerializerContext { }

--- a/InterknotCalculator/Classes/Server/AgentAction.cs
+++ b/InterknotCalculator/Classes/Server/AgentAction.cs
@@ -1,0 +1,9 @@
+﻿using InterknotCalculator.Enums;
+
+namespace InterknotCalculator.Classes.Server;
+
+public class AgentAction {
+    public string Name { get; set; } = "";
+    public SkillTag Tag { get; set; }
+    public double Damage { get; set; }
+}

--- a/InterknotCalculator/Classes/Server/CalcResult.cs
+++ b/InterknotCalculator/Classes/Server/CalcResult.cs
@@ -1,6 +1,6 @@
 namespace InterknotCalculator.Classes.Server;
 
 public class CalcResult {
-    public double[] PerAction { get; set; } = [];
+    public IEnumerable<AgentAction> PerAction { get; set; } = [];
     public double Total { get; set; }
 }

--- a/InterknotCalculator/Classes/Stat.cs
+++ b/InterknotCalculator/Classes/Stat.cs
@@ -1,14 +1,30 @@
-﻿using InterknotCalculator.Enums;
+﻿using System.Text.Json.Serialization;
+using InterknotCalculator.Classes.Extensions;
+using InterknotCalculator.Enums;
 
 namespace InterknotCalculator.Classes;
 
-public record Stat(
-    double Value,
-    Affix Affix,
-    string? Expression = null,
-    IEnumerable<SkillTag>? Tags = null
-) {
-    public double Value { get; set; } = Value;
+public struct Stat {
+    public double Value { get; set; }
+    public Affix Affix { get; set; }
+    public string? Expression { get; set; }
+    public IEnumerable<SkillTag>? Tags { get; set; } = null;
+    
+    [JsonIgnore]
+    public SkillTag[] SkillTags => Tags?.ToArray() ?? [];
+    
+    public Stat(double value, Affix affix, string? expression = null, IEnumerable<SkillTag>? tags = null) {
+        Expression = expression;
+        
+        if (Expression is not null && value == 0d) {
+            Value = Expression.EvaluateExpression();
+        } else {
+            Value = value;
+        }
+        
+        Affix = affix;
+        Tags = tags?.ToArray() ?? [];
+    }
     public static Dictionary<Affix, Stat> SubStats { get; } = new() {
         { Affix.Hp,                 new (112, Affix.Hp) },
         { Affix.Atk,                new (19, Affix.Atk) },

--- a/InterknotCalculator/Enums/SkillTag.cs
+++ b/InterknotCalculator/Enums/SkillTag.cs
@@ -5,5 +5,6 @@ public enum SkillTag {
     QuickAssist, DefensiveAssist, EvasiveAssist, FollowUpAssist,
     Special, ExSpecial, Chain, Ultimate,
   
+    AttributeAnomaly,
     Aftershock
 }

--- a/InterknotCalculator/Enums/SkillTag.cs
+++ b/InterknotCalculator/Enums/SkillTag.cs
@@ -4,7 +4,6 @@ public enum SkillTag {
     BasicAtk, Dash, Counter, 
     QuickAssist, DefensiveAssist, EvasiveAssist, FollowUpAssist,
     Special, ExSpecial, Chain, Ultimate,
-    
-    AttributeAnomaly,
+  
     Aftershock
 }

--- a/InterknotCalculator/Program.cs
+++ b/InterknotCalculator/Program.cs
@@ -11,7 +11,7 @@ public static class Program {
         
         
         var builder = WebApplication.CreateSlimBuilder(args);
-        builder.WebHost.UseUrls($"http://localhost:5101/");
+        builder.WebHost.UseUrls("http://localhost:5101/");
         builder.Services.AddCors(options => {
             options.AddPolicy("AllowAll",
                 policy => {
@@ -41,12 +41,12 @@ public static class Program {
                     d.StatsLevels.Skip(1).Select(p => (p.Value, Stat.SubStats[p.Key])))
             );
             
-            var calcResult = calc.Calculate(result.AgentId, result.WeaponId, discs, result.Rotation);
+            var actions = calc.Calculate(result.AgentId, result.WeaponId, discs, result.Rotation);
             calc.Reset();
             
             return Results.Json(new CalcResult {
-                PerAction = calcResult.PerAction.ToArray(), 
-                Total = calcResult.Total
+                PerAction = actions, 
+                Total = actions.Sum(action => action.Damage)
             }, SerializerContext.Default.CalcResult);
         });
         

--- a/InterknotCalculator/Resources/DriveDiscs/32300.json
+++ b/InterknotCalculator/Resources/DriveDiscs/32300.json
@@ -10,7 +10,6 @@
         }, 
         {
             "Affix": "CritDamage",
-            "Tags": ["AttributeAnomaly"],
             "Value": 0.33
         }
     ]

--- a/InterknotCalculator/Resources/DriveDiscs/32500.json
+++ b/InterknotCalculator/Resources/DriveDiscs/32500.json
@@ -5,7 +5,7 @@
     }],
     "FullBonus": [{
         "Affix": "DmgBonus",
-        "Tags": ["BasicAtk", "Dash", "AttributeAnomaly"],
+        "Tags": ["BasicAtk", "Dash"],
         "Value": 0.2
     }]
 }

--- a/InterknotCalculator/Resources/DriveDiscs/32500.json
+++ b/InterknotCalculator/Resources/DriveDiscs/32500.json
@@ -6,6 +6,6 @@
     "FullBonus": [{
         "Affix": "DmgBonus",
         "Tags": ["BasicAtk", "Dash"],
-        "Value": 0.2
+        "Value": 0.4
     }]
 }

--- a/InterknotCalculator/Resources/DriveDiscs/32700.json
+++ b/InterknotCalculator/Resources/DriveDiscs/32700.json
@@ -1,7 +1,7 @@
 ﻿{
     "PartialBonus": [{
         "Affix": "CritDamage",
-        "Tag": "BasicAtk",
+        "Tags": ["BasicAtk"],
         "Value": 0.16
     }],
     "FullBonus": [

--- a/InterknotCalculator/Resources/DriveDiscs/32700.json
+++ b/InterknotCalculator/Resources/DriveDiscs/32700.json
@@ -1,7 +1,6 @@
 ﻿{
     "PartialBonus": [{
         "Affix": "CritDamage",
-        "Tags": ["BasicAtk"],
         "Value": 0.16
     }],
     "FullBonus": [


### PR DESCRIPTION
Certain damage bonuses will only apply if any of the specified tags match the current action tag.

For example, set 32500 has it's full (4pc) bonus defined like this:
```json
{
    "FullBonus": [{
        "Affix": "DmgBonus",
        "Tags": ["BasicAtk", "Dash"],
        "Value": 0.4
    }]
}
```
Which corresponds to in-game information:
<img width="256" alt="image" src="https://github.com/user-attachments/assets/d9eed85d-4964-418f-96e4-b0902e38fb58" />

This means, that characters wielding this set only get the damage increase on their Basic Attacks and Dash Attacks.

Tag application excludes `AttributeAnomaly` and other timing-related or team-related bonuses and assumes 100% uptime, since that'd require to check precise timings of those tags and we're trying to make a *calculator* here, not a *simulator*.