### PR TITLE
Ye Shunguang and Ether Veils

### DIFF
--- a/InterknotCalculator.Core/Classes/Agents/Dialyn.cs
+++ b/InterknotCalculator.Core/Classes/Agents/Dialyn.cs
@@ -1,0 +1,49 @@
+using System.Runtime.InteropServices.Swift;
+using InterknotCalculator.Core.Enums;
+using InterknotCalculator.Core.Interfaces;
+
+namespace InterknotCalculator.Core.Classes.Agents;
+
+public class Dialyn : SupportAgent, IStunAgent {
+    public Dialyn() : base(AgentId.Dialyn) {
+        Speciality = Speciality.Stun;
+        Element = Element.Physical;
+        Rarity = Rarity.S;
+        Faction = Faction.KrampusComplianceAuthority;
+        
+        Stats[Affix.Hp] = 8250;
+        Stats[Affix.Def] = 612;
+        Stats[Affix.Atk] = 758;
+        Stats[Affix.CritRate] = 0.194;
+        Stats[Affix.CritDamage] = 0.5;
+        Stats[Affix.Impact] = 110;
+        Stats[Affix.AnomalyMastery] = 94;
+        Stats[Affix.AnomalyProficiency] = 93;
+        Stats[Affix.EnergyRegen] = 1.2;
+    }
+
+    public double EnemyStunBonusOverride { get; set; } = 0.3;
+
+    public override void ApplyPassive() {
+        // If her initial CRIT Rate surpasses 50%, her Impact increases
+        // by 2 for each additional 1%, up to a maximum increase of 100.
+        BonusStats[Affix.Impact] += Math.Min(100, Math.Max(0, CritRate - 0.5) * 2);
+    }
+
+    public override IEnumerable<Stat> ApplyTeamPassive(List<Agent> team) {
+        if (team.Count < 2) return [];
+
+        // When another character in your squad is an Attack or Rupture character
+        if (team.Any(a => a is { Speciality: Speciality.Attack or Speciality.Rupture })) {
+            // Dialyn's EX Special Attack CRIT DMG is increased by 50%.
+            TagBonus.Add(new(Affix.CritDamage, 0.5, tags: [SkillTag.ExSpecial]));
+
+            // When an EX Special Attack or Ultimate is activated, all squad members gain the
+            // Overwhelmingly Positive effect.
+            // While Overwhelmingly Positive is active, DMG dealt is increased by 40% for 15s.
+            ExternalBonus[Affix.DmgBonus] += 0.4;
+        }
+        
+        return base.ApplyTeamPassive(team);
+    }
+}

--- a/InterknotCalculator.Core/Classes/Agents/Dialyn.cs
+++ b/InterknotCalculator.Core/Classes/Agents/Dialyn.cs
@@ -1,10 +1,22 @@
-using System.Runtime.InteropServices.Swift;
 using InterknotCalculator.Core.Enums;
 using InterknotCalculator.Core.Interfaces;
 
 namespace InterknotCalculator.Core.Classes.Agents;
 
-public class Dialyn : SupportAgent, IStunAgent {
+public class Dialyn : SupportAgent, IStunAgent, IAgentReference<Dialyn> {
+    public static Dialyn Reference(uint weaponId, uint setId) {
+        var dialyn = new Dialyn {
+            Stats = {
+                [Affix.CritRate] = 1
+            }
+        };
+        
+        dialyn.SetWeapon(weaponId);
+        dialyn.SetDriveDiscsPassive(setId);
+
+        return dialyn;
+    }
+
     public Dialyn() : base(AgentId.Dialyn) {
         Speciality = Speciality.Stun;
         Element = Element.Physical;
@@ -20,6 +32,36 @@ public class Dialyn : SupportAgent, IStunAgent {
         Stats[Affix.AnomalyMastery] = 94;
         Stats[Affix.AnomalyProficiency] = 93;
         Stats[Affix.EnergyRegen] = 1.2;
+        
+        Skills["happy_to_be_of_service"] = new(SkillTag.BasicAtk, [
+            new(52, 29.3, 22.64, 0.408),
+            new(103, 65.5, 49.59, 0.893),
+            new(129.7, 92.4, 68.72, 1.237),
+            new(199.6, 150.1, 125.7, 2.263),
+        ]);
+        Skills["rock_paper_scissors"] = new(SkillTag.BasicAtk, [
+            new(179.7, 107.7, 55, 1.98),
+            new(228.3, 137, 70, 2.52),
+            new(206.5, 124, 63.34, 2.28),
+            new(201.5, 120.7, 61.67, 2.22),
+        ]);
+        Skills["sudden_call"] = new(SkillTag.Dash, [new(121, 45.7, 55, 0.99)]);
+        Skills["number_unavailable"] = new(SkillTag.Counter, [new(534.6, 346.5, 259.97, 3.959)]);
+        Skills["forward_call"] = new(SkillTag.QuickAssist, [new(242, 91.3, 109.97, 1.98)]);
+        Skills["decline_call"] = new(SkillTag.DefensiveAssist, [
+            new(0, 407.7),
+            new(0, 514.4),
+            new(0, 250.4),
+        ]);
+        Skills["back_to_back_calls"] = new(SkillTag.FollowUpAssist, [new(753.7, 491.6, 165)]);
+        Skills["welcome_gesture"] = new(SkillTag.Special, [new(109.2, 81.7, 49.19)]);
+        Skills["get_lost"] = new(SkillTag.ExSpecial, [new(1099.7, 504.8, 160.04, 2.881)]);
+        Skills["rock"] = new(SkillTag.ExSpecial, [new(808.8, 354.8, 61.7, -25)]);
+        Skills["scissors"] = new(SkillTag.ExSpecial, [new(1050.7, 465.3, 86.67, -25)]);
+        Skills["paper"] = new(SkillTag.ExSpecial, [new(1403.5, 641.4, 138.34, -25)]);
+        Skills["welcome_mat"] = new(SkillTag.Chain, [new(1240.8, 272.8, 164.97)]);
+        Skills["service_stopped_for_number_dialed"] = new(SkillTag.Ultimate, [new(3245, 1151.7, 680)]);
+
     }
 
     public double EnemyStunBonusOverride { get; set; } = 0.3;

--- a/InterknotCalculator.Core/Classes/Agents/Ellen.cs
+++ b/InterknotCalculator.Core/Classes/Agents/Ellen.cs
@@ -87,8 +87,12 @@ public class Ellen : Agent {
     }
 
     public override Stat? ApplyAbilityPassive(Ability ability) {
+        if (ability.Tag is SkillTag.Chain or SkillTag.Ultimate) {
+            return new(Affix.CritDamage, 1);
+        }
+        
         switch (ability.Name) {
-            case "flash_freeze_trimming":
+            case "flash_freeze_trimming" or "icy_blade" or "glacial_blade_wave":
                 return new(Affix.CritDamage, 1);
             default:
                 return null;

--- a/InterknotCalculator.Core/Classes/Agents/Sunna.cs
+++ b/InterknotCalculator.Core/Classes/Agents/Sunna.cs
@@ -32,6 +32,34 @@ public class Sunna : SupportAgent, IAgentReference<Sunna>, IEtherVeilAgent<Delus
         Stats[Affix.AnomalyMastery] = 96;
         Stats[Affix.AnomalyProficiency] = 95;
         Stats[Affix.EnergyRegen] = 1;
+
+        Skills["mischief_meteor_hammer"] = new(SkillTag.BasicAtk, [
+            new(87.4, 38, 12.5, 0.451),
+            new(351.9, 164.1, 52.65, 1.896),
+            new(362.7, 186.3, 56.74, 2.043),
+            new(811.2, 378.2, 116.43, 4.192),
+        ]);
+        Skills["naughty_cat_spotted"] = new(SkillTag.BasicAtk, [new(417, 0, element: Element.Physical)]);
+        Skills["skyward_hammer"] = new(SkillTag.Dash, [new(199.8, 75.2, 19.16, 1.381)]);
+        Skills["delusion_strikeout"] = new(SkillTag.Counter, [new(637.8, 413.9, 55.84, 4.022)]);
+        Skills["sonic_beatdown"] = new(SkillTag.QuickAssist, [new(146.4, 110.1, 27.92, 2.011)]);
+        Skills["stage_fright"] = new(SkillTag.DefensiveAssist, [
+            new(0, 481.3),
+            new(0, 608.7),
+            new(0, 296.2),
+        ]);
+        Skills["jump_training"] = new(SkillTag.FollowUpAssist, [new(1071.4, 708.2, 193.71)]);
+        Skills["star_shooter"] = new(SkillTag.Special, [new(113.6, 85, 21.67)]);
+        Skills["bubblegum_barrage"] = new(SkillTag.ExSpecial, [
+            new(1827.4, 921.8, 171.02 + 45.81, -70),
+            new(1588.3, 742.1, 171.02, -70),
+        ]);
+        Skills["special_photography_technique"] = new(SkillTag.ExSpecial, [
+            new(1656.4, 903.7, 217.16),
+            new(1905, 1040.3, 217.16),
+        ]);
+        Skills["don't_mess_with_the_cat"] = new(SkillTag.Chain, [new(1623.1, 438.9, 212.26)]);
+        Skills["smash_it_all"] = new(SkillTag.Ultimate, [new(4182, 559.8, 143.35)]);
     }
 
     public override void RegisterHooks(Context ctx) {
@@ -59,7 +87,14 @@ public class Sunna : SupportAgent, IAgentReference<Sunna>, IEtherVeilAgent<Delus
 
         ctx.Events.OnActionExecuted.Add((c, e) => {
             if (!CatsGazeActive || CatsGazeCooldown != 0) return;
-            CatsGazeActive = false;
+            // if (ClawSharpenersCount <= 0) { 
+            //     CatsGazeActive = false;
+            //     return;
+            // }
+            //
+            // ClawSharpenersCount--;
+            // CatsGazeActive = true;
+            // CatsGazeCooldown = 4;
 
             var agent = e.Agent;
 
@@ -82,21 +117,45 @@ public class Sunna : SupportAgent, IAgentReference<Sunna>, IEtherVeilAgent<Delus
                 0
             ));
 
-            if (ClawSharpenersCount <= 0) return;
-            
-            ClawSharpenersCount--;
-            CatsGazeActive = true;
+            // Reapply "Cat's Gaze" if a "Claw Sharpener" is available,
+            // consuming one. Otherwise, let the effect expire
+            CatsGazeActive = ClawSharpenersCount > 0;
+            if (CatsGazeActive) {
+                ClawSharpenersCount--;
+                CatsGazeCooldown = 4;
+            }
         });
         
         ctx.Events.OnAnomalyTriggered.Add((_, _) => {
             ClawSharpenersCount += 1;
         });
         
-        ctx.Events.OnEtherVeilActivated.Add((_, _) => {
+        ctx.Events.OnEtherVeilActivated.Add((c, e) => {
             ClawSharpenersCount += 2;
+
+            if (IsTeamPassiveActive && e.Agent == this) {
+                c.Enemy.StunMultiplier += 0.3;
+            }
+        });
+        
+        ctx.Events.OnEtherVeilDeactivated.Add((c, e) => {
+            if (IsTeamPassiveActive && e.Agent == this) {
+                c.Enemy.StunMultiplier -= 0.3;
+            }
         });
     }
-
-
+    
     public DelusionReprise EtherVeil { get; } = new();
+
+    private bool IsTeamPassiveActive { get; set; } = false;
+    
+    public override IEnumerable<Stat> ApplyTeamPassive(List<Agent> team) {
+        if (team.Count < 2) return [];
+
+        if (team.Any(a => a.Speciality is Speciality.Attack || a.Faction == Faction)) {
+            IsTeamPassiveActive = true;
+        }
+        
+        return [];
+    }
 }

--- a/InterknotCalculator.Core/Classes/Agents/Sunna.cs
+++ b/InterknotCalculator.Core/Classes/Agents/Sunna.cs
@@ -24,7 +24,10 @@ public class Sunna : SupportAgent, IAgentReference<Sunna>, IEtherVeilAgent<Delus
         set => field = Math.Clamp(value, 0, 6);
     } = 0;
     private bool CatsGazeActive { get; set; } = false;
-    private int CatsGazeCooldown { get; set; } = 4;
+    private int CatsGazeCooldown { 
+        get; 
+        set => field = Math.Clamp(value, 0, 4); 
+    } = 4;
     
     public Sunna() : base(AgentId.Sunna) {
         Speciality = Speciality.Support;
@@ -85,6 +88,7 @@ public class Sunna : SupportAgent, IAgentReference<Sunna>, IEtherVeilAgent<Delus
                     or "don't_mess_with_the_cat"
                     or "smash_it_all") {
                 CatsGazeActive = true;
+                CatsGazeCooldown = 4;
             } else {
                 if (c.Enemy.StunMultiplier > 1 && CatsGazeActive) {
                     CatsGazeCooldown -= 4;
@@ -96,14 +100,6 @@ public class Sunna : SupportAgent, IAgentReference<Sunna>, IEtherVeilAgent<Delus
 
         ctx.Events.OnActionExecuted.Add((c, e) => {
             if (!CatsGazeActive || CatsGazeCooldown != 0) return;
-            // if (ClawSharpenersCount <= 0) { 
-            //     CatsGazeActive = false;
-            //     return;
-            // }
-            //
-            // ClawSharpenersCount--;
-            // CatsGazeActive = true;
-            // CatsGazeCooldown = 4;
 
             var agent = e.Agent;
 

--- a/InterknotCalculator.Core/Classes/Agents/Sunna.cs
+++ b/InterknotCalculator.Core/Classes/Agents/Sunna.cs
@@ -72,12 +72,13 @@ public class Sunna : SupportAgent, IAgentReference<Sunna>, IEtherVeilAgent<Delus
                 : 1 + agent.CritRate * agent.CritDamage;
             var dmgBonus = 1 + agent.ElementalDmgBonus + agent.DmgBonus;
             var resPen = 1 + agent.ElementalResPen + agent.ResPen;
+            var stunBonus = 1 + c.Enemy.StunMultiplier;
                 
             c.ActionsQueue.Add(new(
-                c.MainAgentId,
+                agent.Id,
                 "cat's_gaze", 
                 SkillTag.DirectHit, 
-                baseDmg * critMultiplier * dmgBonus * resPen * c.Enemy.GetDefenseMultiplier(agent.PenRatio, agent.Pen), 
+                baseDmg * critMultiplier * dmgBonus * resPen * c.Enemy.GetDefenseMultiplier(agent.PenRatio, agent.Pen) * stunBonus, 
                 0
             ));
 

--- a/InterknotCalculator.Core/Classes/Agents/Sunna.cs
+++ b/InterknotCalculator.Core/Classes/Agents/Sunna.cs
@@ -1,0 +1,101 @@
+using System.IO.Pipes;
+using InterknotCalculator.Core.Classes.EtherVeils;
+using InterknotCalculator.Core.Enums;
+using InterknotCalculator.Core.Interfaces;
+
+namespace InterknotCalculator.Core.Classes.Agents;
+
+public class Sunna : SupportAgent, IAgentReference<Sunna>, IEtherVeilAgent<DelusionReprise> {
+    public static Sunna Reference(uint weaponId, uint setId) {
+        return new();
+    }
+
+    private int ClawSharpenersCount {
+        get;
+        set => field = Math.Clamp(value, 0, 6);
+    } = 0;
+    private bool CatsGazeActive { get; set; } = false;
+    private int CatsGazeCooldown { get; set; } = 4;
+    
+    public Sunna() : base(AgentId.Sunna) {
+        Speciality = Speciality.Support;
+        Element = Element.Physical;
+        Rarity = Rarity.S;
+        Faction = Faction.AngelsOfDelusion;
+            
+        Stats[Affix.Hp] = 8477;
+        Stats[Affix.Def] = 600;
+        Stats[Affix.Atk] = 750;
+        Stats[Affix.CritRate] = 0.05;
+        Stats[Affix.CritDamage] = 0.5;
+        Stats[Affix.Impact] = 98;
+        Stats[Affix.AnomalyMastery] = 96;
+        Stats[Affix.AnomalyProficiency] = 95;
+        Stats[Affix.EnergyRegen] = 1;
+    }
+
+    public override void RegisterHooks(Context ctx) {
+        ctx.Events.OnActionExecuted.Add((c, e) => {
+            if (e.Ability is { Tag: Enums.SkillTag.ExSpecial, Name: "special_photography_technique" }) {
+                c.ReactivateEtherVeil(this, EtherVeil);
+            }
+        });
+        
+        ctx.Events.OnActionExecuted.Add((c, e) => {
+            if (e.Agent == this && e.Ability.Name is "naughty_cat_spotted"
+                    or "bubblegum_barrage"
+                    or "special_photography_technique"
+                    or "don't_mess_with_the_cat"
+                    or "smash_it_all") {
+                CatsGazeActive = true;
+            } else {
+                if (c.Enemy.StunMultiplier > 1 && CatsGazeActive) {
+                    CatsGazeCooldown -= 4;
+                } else {
+                    CatsGazeCooldown--;
+                }
+            }
+        });
+
+        ctx.Events.OnActionExecuted.Add((c, e) => {
+            if (!CatsGazeActive || CatsGazeCooldown != 0) return;
+            CatsGazeActive = false;
+
+            var agent = e.Agent;
+
+            if (agent is not { Speciality: Speciality.Attack or Speciality.Anomaly }) return;
+                
+            var baseDmg = agent.Speciality is Speciality.Anomaly
+                ? agent.Atk * 4.8 : agent.Atk * 3.0;
+            var critMultiplier = agent.Speciality is Speciality.Anomaly
+                ? 1 + 1 * (1.5 + agent.CritDamage)
+                : 1 + agent.CritRate * agent.CritDamage;
+            var dmgBonus = 1 + agent.ElementalDmgBonus + agent.DmgBonus;
+            var resPen = 1 + agent.ElementalResPen + agent.ResPen;
+                
+            c.ActionsQueue.Add(new(
+                c.MainAgentId,
+                "cat's_gaze", 
+                SkillTag.DirectHit, 
+                baseDmg * critMultiplier * dmgBonus * resPen * c.Enemy.GetDefenseMultiplier(agent.PenRatio, agent.Pen), 
+                0
+            ));
+
+            if (ClawSharpenersCount <= 0) return;
+            
+            ClawSharpenersCount--;
+            CatsGazeActive = true;
+        });
+        
+        ctx.Events.OnAnomalyTriggered.Add((_, _) => {
+            ClawSharpenersCount += 1;
+        });
+        
+        ctx.Events.OnEtherVeilActivated.Add((_, _) => {
+            ClawSharpenersCount += 2;
+        });
+    }
+
+
+    public DelusionReprise EtherVeil { get; } = new();
+}

--- a/InterknotCalculator.Core/Classes/Agents/Sunna.cs
+++ b/InterknotCalculator.Core/Classes/Agents/Sunna.cs
@@ -7,7 +7,16 @@ namespace InterknotCalculator.Core.Classes.Agents;
 
 public class Sunna : SupportAgent, IAgentReference<Sunna>, IEtherVeilAgent<DelusionReprise> {
     public static Sunna Reference(uint weaponId, uint setId) {
-        return new();
+        var sunna = new Sunna {
+            Stats = {
+                [Affix.Atk] = 3500
+            }
+        };
+        
+        sunna.SetWeaponPassive(weaponId);
+        sunna.SetDriveDiscsPassive(setId);
+        
+        return sunna;
     }
 
     private int ClawSharpenersCount {

--- a/InterknotCalculator.Core/Classes/Agents/YeShunguang.cs
+++ b/InterknotCalculator.Core/Classes/Agents/YeShunguang.cs
@@ -1,0 +1,215 @@
+using InterknotCalculator.Core.Classes.EtherVeils;
+using InterknotCalculator.Core.Classes.Server;
+using InterknotCalculator.Core.Enums;
+using InterknotCalculator.Core.Interfaces;
+
+namespace InterknotCalculator.Core.Classes.Agents;
+
+public class YeShunguang : Agent, IEtherVeilAgent<Verdict> {
+    protected double VeilVulnerabilityCap { get; }
+    protected int MaxQingmingSwordForce { get; }
+    protected int MaxBearer { get; }
+    
+    public YeShunguang() : base(AgentId.YeShunguang) {
+        Speciality = Speciality.Attack;
+        Element = Element.HonedEdge;
+        Rarity = Rarity.S;
+        Faction = Faction.YunkuiSummit;
+        
+        Stats[Affix.Hp] = 7673;
+        Stats[Affix.Def] = 606;
+        Stats[Affix.Atk] = 938;
+        Stats[Affix.CritRate] = 0.194;
+        Stats[Affix.CritDamage] = 0.5;
+        Stats[Affix.Impact] = 83;
+        Stats[Affix.AnomalyMastery] = 94;
+        Stats[Affix.AnomalyProficiency] = 93;
+        Stats[Affix.EnergyRegen] = 1.2;
+
+        VeilVulnerabilityCap = 1.1;
+        MaxQingmingSwordForce = 6;
+        MaxBearer = 3;
+        
+        Skills["swiftedge"] = new(SkillTag.BasicAtk, [
+            new(159.7, 40.8, element: Element.Physical, energy: 1.734),
+            new(488.3, 117.1, element: Element.Physical, energy: 5.07),
+            new(250, 54.1, element: Element.Physical, energy: 2.315),
+            new(736.5, 161.2, element: Element.Physical, energy: 7.019),
+        ]);
+        Skills["cloudstream_sword_will"] = new(SkillTag.BasicAtk, [new(234.4, 55.4, element: Element.Physical)]);
+        Skills["enlightened_mind_splitting_currents"] = new(SkillTag.BasicAtk, [
+            new(225.9, 54.5, 65),
+            new(312.1, 74.8, 90),
+            new(433.3, 104, 125),
+        ]);
+        Skills["enlightened_mind_skyward_ascent"] = new(SkillTag.BasicAtk, [new(182.3, 54.5, 32.5)]);
+        Skills["enlightened_mind_sunderlight_maximum"] = new(SkillTag.BasicAtk, [new(1209.8, 115.5, 140)]);
+        Skills["enlightened_mind_sunderlight"] = new(SkillTag.BasicAtk, [
+            new(241.7, 51.6, 61.66),
+            new(313.8, 66, 80),
+        ]);
+        Skills["enlightened_mind_sunderlight_annihilation"] = new(SkillTag.BasicAtk, [
+            new(320.5, 68.1, 81.69),
+            new(1783.3, 87.5, 105.03),
+        ]);
+        Skills["phantasm_dash"] = new(SkillTag.Dash, [new(210.6, 31.7, element: Element.Physical, energy: 1.35)]);
+        Skills["swallow_strike"] = new(SkillTag.Counter, [new(692.8, 176.8, element: Element.Physical, energy: 4.08)]);
+        Skills["illuminating_darkness"] = new(SkillTag.Entry, [new(800.8, 181.5, 220)]);
+        Skills["support_guard"] = new(SkillTag.QuickAssist, [new(161.9, 48.2, element: Element.Physical, energy: 2.07)]);
+        Skills["enlightened_mind_tactical_support"] = new(SkillTag.QuickAssist, [new(135.5, 50.7, 60)]);
+        Skills["when_i_return"] = new(SkillTag.DefensiveAssist, [
+            new(0, 293.2),
+            new(0, 311.7),
+            new(0, 179.7),
+        ]);
+        Skills["enlightened_mind_unification_illuminating_darkness"] = new(SkillTag.FollowUpAssist, [new(800.8, 181.5, 220)]);
+        Skills["cease_hostility"] = new(SkillTag.FollowUpAssist, [new(828.4, 210.4, element: Element.Physical)]);
+        Skills["enlightened_mind_unification"] = new(SkillTag.FollowUpAssist, [new(860.1, 219.7, 286.22)]);
+        Skills["guiding_tides"] = new(SkillTag.Special, [
+            new(197.9, 37.5, element: Element.Physical),
+            new(632.7, 199.2, element: Element.Physical),
+        ]);
+        Skills["enlightened_mind_clean_exit"] = new(SkillTag.Special, [new(142.5, 26.3, 31.66)]);
+        Skills["gale_suppression"] = new(SkillTag.ExSpecial, [new(2357.6, 510.6, element: Element.Physical, energy: -60)]);
+        Skills["enlightened_mind_soaring_light"] = new(SkillTag.ExSpecial, [
+            new(352.7, 27.2, 32.78),
+            new(2116.2, 163.2, 196.66),
+        ]);
+        Skills["enlightened_mind_return_to_dust"] = new(SkillTag.ExSpecial, [new(2322.7, 209.8, 253.33)]);
+        Skills["smite_the_wicked"] = new(SkillTag.Chain, [new(1743.9, 272.8, element: Element.Physical)]);
+        Skills["enlightened_mind_lure_thunder"] = new(SkillTag.Chain, [new(1817.2, 206.8, 449.5)]);
+        Skills["chasing_storms"] = new(SkillTag.Ultimate, [new(3850, 82.5, 100)]);
+        Skills["cleaving_heavens"] = new(SkillTag.Ultimate, [new(6168.7, 227.2, 275)]);
+    }
+
+    private bool IsTeamPassiveActive { get; set; } = false;
+
+    private bool IsEnlightenedMind { get; set; } = false;
+    
+    public int QingmingSwordForce {
+        get;
+        set => field = Math.Clamp(value, 0, MaxQingmingSwordForce);
+    }
+    private int Bearer {
+        get;
+        set => field = Math.Clamp(value, 0, MaxBearer);
+    }
+    
+    private void GainSwordForce(int amount) {
+        if (IsEnlightenedMind) {
+            // While in Enlightened Mind, gained Force converts to Bearer stacks
+            Bearer += amount;
+            return;
+        }
+
+        var overflow = QingmingSwordForce + amount - MaxQingmingSwordForce;
+        QingmingSwordForce += amount;
+        if (overflow > 0) Bearer += overflow;
+    }
+    
+    private void EnterEnlightenedMind(Context ctx) {
+        if (QingmingSwordForce != 6)
+            throw new InvalidOperationException("Cannot enter Enlightened Mind with less than 6 Qingming Sword Force");
+        
+        if (!IsEnlightenedMind) IsEnlightenedMind = true;
+        if (ctx.GetEtherVeil<Verdict>() is { } existing) {
+            ctx.DeactivateEtherVeil(this, existing);
+        }
+        ctx.ActivateEtherVeil(this, EtherVeil);
+    }
+
+    private void ExitEnlightenedMind(Context ctx) {
+        if (!IsEnlightenedMind) 
+            throw new InvalidOperationException("Cannot exit Enlightened Mind without entering it first");
+        
+        if (ctx.GetEtherVeil<Verdict>() is { } verdict) {
+            ctx.DeactivateEtherVeil(this, verdict);
+        }
+        if (IsEnlightenedMind) IsEnlightenedMind = false;
+
+        // Bearer stacks are converted back into Qingming Sword Force
+        QingmingSwordForce += Bearer;
+        Bearer = 0;
+    }
+    
+    public override void ApplyPassive() {
+        // Core Passive: Burning Clarity
+        BonusStats[Affix.CritRate] += 0.3;
+        BonusStats[Affix.DmgBonus] += 0.25;
+    }
+    
+    public override void RegisterHooks(Context ctx) {
+        ctx.Events.OnActionExecuted.Add((c, e) => {
+            if (e.Agent != this) return;
+
+            switch (e.Ability.Name) {
+                // Ultimate: Chasing Storms grants 6 Qingming Sword Force,
+                // then enters Enlightened Mind and activates "Ether Veil: Verdict"
+                case "chasing_storms":
+                    GainSwordForce(6);
+                    EnterEnlightenedMind(c);
+                    break;
+
+                // Entry Skill: Illuminating Darkness requires full Qingming Sword Force
+                case "illuminating_darkness":
+                    EnterEnlightenedMind(c);
+                    break;
+
+                // Qingming Sword Force consumption
+                case "enlightened_mind_soaring_light" or "enlightened_mind_sunderlight_maximum":
+                    QingmingSwordForce -= 1;
+                    break;
+                case "enlightened_mind_sunderlight_annihilation" when e.Ability.Scale == 1:
+                    QingmingSwordForce -= 2;
+                    break;
+            }
+        });
+
+        // Additional Ability: Shadowtrace Flight 
+        // when a squadmate activates any Ether Veil, gain 3 Qingming Sword Force
+        // (converted to Bearer stacks if already in Enlightened Mind)
+        ctx.Events.OnEtherVeilActivated.Add((_, e) => {
+            if (!IsTeamPassiveActive || e.Agent == this) return;
+            GainSwordForce(3);
+        });
+    }
+
+    protected double OriginalEnemyStunMultiplier { get; set; } = 1;
+    
+    public override IEnumerable<AgentAction> GetActionDamage(Context ctx, Ability ability) {
+        OriginalEnemyStunMultiplier = ctx.Enemy.StunMultiplier; // 1
+
+        // Core Passive: Burning Clarity
+        // Veil Vulnerability: while "Ether Veil: Verdict" is active, the enemy's Stun DMG multiplier
+        // is ignored and replaced with the Veil Vulnerability bonus, capped at 110%.
+        if (IsEnlightenedMind && ctx.GetEtherVeil<Verdict>() is not null) {
+            ctx.Enemy.StunMultiplier = Math.Min(1 + VeilVulnerabilityCap, OriginalEnemyStunMultiplier + 0.5);
+        }
+
+        try {
+            return base.GetActionDamage(ctx, ability).ToList();
+        } finally {
+            ctx.Enemy.StunMultiplier = OriginalEnemyStunMultiplier;
+
+            // Exiting Enlightened Mind removes "Ether Veil: Verdict"
+            // after the finisher's damage has been resolved
+            if (ability.Name is "cleaving_heavens" or "enlightened_mind_return_to_dust") {
+                ExitEnlightenedMind(ctx);
+            }
+        }
+    }
+    
+    public override IEnumerable<Stat> ApplyTeamPassive(List<Agent> team) {
+        if (team.Count < 2) return [];
+
+        // Additional Ability: Shadowtrace Flight 
+        // requires a Support or Defense character in the squad
+        if (team.Any(a => a.Speciality is Speciality.Support or Speciality.Defense)) {
+            IsTeamPassiveActive = true;
+        }
+
+        return [];
+    }
+    
+    public Verdict EtherVeil { get; } = new();
+}

--- a/InterknotCalculator.Core/Classes/Agents/Zhao.cs
+++ b/InterknotCalculator.Core/Classes/Agents/Zhao.cs
@@ -1,0 +1,92 @@
+using InterknotCalculator.Core.Classes.EtherVeils;
+using InterknotCalculator.Core.Enums;
+using InterknotCalculator.Core.Interfaces;
+
+namespace InterknotCalculator.Core.Classes.Agents;
+
+public class Zhao : SupportAgent, IAgentReference<Zhao>, IEtherVeilAgent<Wellspring> {
+    public static Zhao Reference(uint weaponId, uint setId) {
+        var zhao = new Zhao();
+
+        zhao.SetWeaponPassive(weaponId);
+        zhao.SetDriveDiscsPassive(setId);
+
+        return zhao;
+    }
+
+    public Zhao() : base(AgentId.Zhao) {
+        Speciality = Speciality.Defense;
+        Element = Element.Ice;
+        Rarity = Rarity.S;
+        Faction = Faction.KrampusComplianceAuthority;
+
+        Stats[Affix.Hp] = 9117;
+        Stats[Affix.Def] = 301;
+        Stats[Affix.Atk] = 765;
+        Stats[Affix.CritRate] = 0.05;
+        Stats[Affix.CritDamage] = 0.5;
+        Stats[Affix.Impact] = 93;
+        Stats[Affix.AnomalyMastery] = 93;
+        Stats[Affix.AnomalyProficiency] = 96;
+
+        Skills["burst_of_frost"] = new(SkillTag.Entry, [
+            new(1361.2, 345.7, 209.18, 7.531)
+        ]);
+    }
+
+    private bool IsTeamPassiveActive { get; set; } = false;
+    private bool IsTeamPassiveActivated { get; set; } = false;
+    
+    public override void RegisterHooks(Context ctx) {
+        ctx.Events.OnActionExecuted.Add((c, e) => {
+            // Zhao triggered an action
+            if (e.Agent != this) return;
+
+            // Zhao used an entry or ex-special
+            if (e.Ability is not { Tag: SkillTag.Entry or SkillTag.ExSpecial }) return;
+
+            // Assume always full Frostbite Points, because I can't be bothered
+            if (c.GetEtherVeil<Wellspring>() is { } wellspring) {
+                // Overwrite existing Ether Veil if it already exists
+                c.DeactivateEtherVeil(this, wellspring);
+            }
+            c.ActivateEtherVeil(this, EtherVeil);
+        });
+
+        // Core Passive
+        ctx.Events.OnEtherVeilActivated.Add((c, e) => {
+            // Team passive
+            if (IsTeamPassiveActive && !IsTeamPassiveActivated) {
+                IsTeamPassiveActivated = true;
+                foreach (var (_, agent) in c.Team) {
+                    agent.BonusStats[Affix.DmgBonus] += 0.1 + Math.Min(0.4, Math.Max(0, MaxHp - 15000) / 400);
+                }
+            }
+            
+            if (e.Agent != this && e.EtherVeil is not Wellspring) return;
+
+            foreach (var (_, agent) in c.Team) {
+                agent.BonusStats[Affix.Atk] += 1000;
+            }
+        });
+        ctx.Events.OnEtherVeilDeactivated.Add((c, e) => {
+            if (e.Agent != this && e.EtherVeil is not Wellspring) return;
+
+            foreach (var (_, agent) in c.Team) {
+                agent.BonusStats[Affix.Atk] -= 1000;
+            }
+        });
+    }
+    
+    public override IEnumerable<Stat> ApplyTeamPassive(List<Agent> team) {
+        if (team.Count < 2) return [];
+
+        if (team.Any(a => a.Speciality is Speciality.Attack or Speciality.Anomaly or Speciality.Support)) {
+            IsTeamPassiveActive = true;
+        }
+
+        return [];
+    }
+
+    public Wellspring EtherVeil { get; } = new();
+}

--- a/InterknotCalculator.Core/Classes/Agents/Zhao.cs
+++ b/InterknotCalculator.Core/Classes/Agents/Zhao.cs
@@ -45,12 +45,9 @@ public class Zhao : SupportAgent, IAgentReference<Zhao>, IEtherVeilAgent<Wellspr
             // Zhao used an entry or ex-special
             if (e.Ability is not { Tag: SkillTag.Entry or SkillTag.ExSpecial }) return;
 
-            // Assume always full Frostbite Points, because I can't be bothered
-            if (c.GetEtherVeil<Wellspring>() is { } wellspring) {
-                // Overwrite existing Ether Veil if it already exists
-                c.DeactivateEtherVeil(this, wellspring);
-            }
-            c.ActivateEtherVeil(this, EtherVeil);
+            // Assume always full Frostbite Points, because I can't be bothered.
+            // Overwrites the existing Ether Veil if it already exists
+            c.ReactivateEtherVeil(this, EtherVeil);
         });
 
         // Core Passive
@@ -63,14 +60,14 @@ public class Zhao : SupportAgent, IAgentReference<Zhao>, IEtherVeilAgent<Wellspr
                 }
             }
             
-            if (e.Agent != this && e.EtherVeil is not Wellspring) return;
+            if (e.Agent != this || e.EtherVeil is not Wellspring) return;
 
             foreach (var (_, agent) in c.Team) {
                 agent.BonusStats[Affix.Atk] += 1000;
             }
         });
         ctx.Events.OnEtherVeilDeactivated.Add((c, e) => {
-            if (e.Agent != this && e.EtherVeil is not Wellspring) return;
+            if (e.Agent != this || e.EtherVeil is not Wellspring) return;
 
             foreach (var (_, agent) in c.Team) {
                 agent.BonusStats[Affix.Atk] -= 1000;

--- a/InterknotCalculator.Core/Classes/Calculator.cs
+++ b/InterknotCalculator.Core/Classes/Calculator.cs
@@ -80,6 +80,7 @@ public static class Calculator {
         foreach (var a in ctx.Team.Values) {
             fullTeamPassive.AddRange(a.ApplyTeamPassive([..ctx.Team.Values]));
             a.RegisterHooks(ctx);
+            a.Weapon?.RegisterHooks(ctx);
         }
         
         foreach (var stat in fullTeamPassive) {

--- a/InterknotCalculator.Core/Classes/Context.cs
+++ b/InterknotCalculator.Core/Classes/Context.cs
@@ -1,6 +1,8 @@
-using System.Collections.Immutable;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using InterknotCalculator.Core.Classes.Agents;
 using InterknotCalculator.Core.Classes.Enemies;
+using InterknotCalculator.Core.Classes.EtherVeils;
 using InterknotCalculator.Core.Classes.Events;
 using InterknotCalculator.Core.Classes.Server;
 
@@ -22,11 +24,25 @@ public sealed class Context {
     /// </remarks>
     public double AnomalyCritMultiplier { get; set; } = 1;
 
+    private List<EtherVeil> EtherVeils { get; set; } = [];
+    public bool IsEtherVeilActive => EtherVeils.Count > 0;
+    public T? GetEtherVeil<T>() where T : EtherVeil => EtherVeils.OfType<T>().FirstOrDefault();
+
+    public void ActivateEtherVeil(Agent agent, EtherVeil veil) {
+        veil.Activate(this);
+        EtherVeils.Add(veil);
+        Events.EtherVeilActivated(this, new(agent, veil));
+    }
+    public void DeactivateEtherVeil(Agent agent, EtherVeil veil) {
+        veil.Deactivate(this);
+        EtherVeils.Remove(veil);
+        Events.EtherVeilDeactivated(this, new(agent, veil));
+    }
+
     public void ProcessActionsQueue() { 
         if (ActionsQueue.Count > 0) {
             Actions.AddRange(ActionsQueue);
             ActionsQueue.Clear();
         }
     }
-
 }

--- a/InterknotCalculator.Core/Classes/Context.cs
+++ b/InterknotCalculator.Core/Classes/Context.cs
@@ -27,11 +27,13 @@ public sealed class Context {
     public T? GetEtherVeil<T>() where T : EtherVeil => EtherVeils.OfType<T>().FirstOrDefault();
 
     public void ActivateEtherVeil(Agent agent, EtherVeil veil) {
+        if (EtherVeils.Contains(veil)) return;
         veil.Activate(this);
         EtherVeils.Add(veil);
         Events.EtherVeilActivated(this, new(agent, veil));
     }
     public void DeactivateEtherVeil(Agent agent, EtherVeil veil) {
+        if (!EtherVeils.Contains(veil)) return;
         veil.Deactivate(this);
         EtherVeils.Remove(veil);
         Events.EtherVeilDeactivated(this, new(agent, veil));

--- a/InterknotCalculator.Core/Classes/Context.cs
+++ b/InterknotCalculator.Core/Classes/Context.cs
@@ -1,5 +1,3 @@
-using System.Collections.ObjectModel;
-using System.Collections.Specialized;
 using InterknotCalculator.Core.Classes.Agents;
 using InterknotCalculator.Core.Classes.Enemies;
 using InterknotCalculator.Core.Classes.EtherVeils;
@@ -37,6 +35,12 @@ public sealed class Context {
         veil.Deactivate(this);
         EtherVeils.Remove(veil);
         Events.EtherVeilDeactivated(this, new(agent, veil));
+    }
+    public void ReactivateEtherVeil(Agent agent, EtherVeil veil) {
+        if (EtherVeils.Contains(veil)) {
+            DeactivateEtherVeil(agent, veil);
+        }
+        ActivateEtherVeil(agent, veil);
     }
 
     public void ProcessActionsQueue() { 

--- a/InterknotCalculator.Core/Classes/EtherVeils/ColdBlooded.cs
+++ b/InterknotCalculator.Core/Classes/EtherVeils/ColdBlooded.cs
@@ -1,0 +1,9 @@
+using InterknotCalculator.Core.Enums;
+
+namespace InterknotCalculator.Core.Classes.EtherVeils;
+
+public class ColdBlooded : EtherVeil {
+    public ColdBlooded() {
+        BonusStats[Affix.CritDamage] += 0.05;
+    }
+}

--- a/InterknotCalculator.Core/Classes/EtherVeils/DelusionReprise.cs
+++ b/InterknotCalculator.Core/Classes/EtherVeils/DelusionReprise.cs
@@ -1,0 +1,9 @@
+using InterknotCalculator.Core.Enums;
+
+namespace InterknotCalculator.Core.Classes.EtherVeils;
+
+public class DelusionReprise : EtherVeil {
+    public DelusionReprise() {
+        BonusStats[Affix.Atk] += 50;
+    }
+}

--- a/InterknotCalculator.Core/Classes/EtherVeils/EtherVeil.cs
+++ b/InterknotCalculator.Core/Classes/EtherVeils/EtherVeil.cs
@@ -1,0 +1,23 @@
+using InterknotCalculator.Core.Enums;
+
+namespace InterknotCalculator.Core.Classes.EtherVeils;
+
+public abstract class EtherVeil {
+    public SafeDictionary<Affix, double> BonusStats { get; set; } = new();
+
+    public void Activate(Context ctx) {
+        foreach (var (_, agent) in ctx.Team) {
+            foreach (var (affix, bonus) in BonusStats) {
+                agent.BonusStats[affix] += bonus;
+            }
+        }
+    }
+    
+    public void Deactivate(Context ctx) {
+        foreach (var (_, agent) in ctx.Team) {
+            foreach (var (affix, bonus) in BonusStats) {
+                agent.BonusStats[affix] -= bonus;
+            }
+        }
+    }
+}

--- a/InterknotCalculator.Core/Classes/EtherVeils/Verdict.cs
+++ b/InterknotCalculator.Core/Classes/EtherVeils/Verdict.cs
@@ -1,0 +1,5 @@
+namespace InterknotCalculator.Core.Classes.EtherVeils;
+
+public class Verdict : EtherVeil {
+    // no-op
+}

--- a/InterknotCalculator.Core/Classes/EtherVeils/Wellspring.cs
+++ b/InterknotCalculator.Core/Classes/EtherVeils/Wellspring.cs
@@ -1,0 +1,9 @@
+using InterknotCalculator.Core.Enums;
+
+namespace InterknotCalculator.Core.Classes.EtherVeils;
+
+public class Wellspring : EtherVeil {
+    public Wellspring() {
+        BonusStats[Affix.HpRatio] += 0.05;
+    }
+}

--- a/InterknotCalculator.Core/Classes/Events/EtherVeilEventArgs.cs
+++ b/InterknotCalculator.Core/Classes/Events/EtherVeilEventArgs.cs
@@ -1,0 +1,10 @@
+using InterknotCalculator.Core.Classes.Agents;
+using InterknotCalculator.Core.Classes.EtherVeils;
+using InterknotCalculator.Core.Interfaces;
+
+namespace InterknotCalculator.Core.Classes.Events;
+
+public class EtherVeilEventArgs(Agent agent, EtherVeil etherVeil) : EventArgs, ICalcEventArgs {
+    public Agent Agent { get; } = agent;
+    public EtherVeil EtherVeil { get; } = etherVeil;
+}

--- a/InterknotCalculator.Core/Classes/Events/EventBus.cs
+++ b/InterknotCalculator.Core/Classes/Events/EventBus.cs
@@ -1,3 +1,5 @@
+using InterknotCalculator.Core.Classes.EtherVeils;
+
 namespace InterknotCalculator.Core.Classes.Events;
 
 public sealed class EventBus {
@@ -6,12 +8,16 @@ public sealed class EventBus {
     public delegate void AnomalyBuildupEvent(Context ctx, AnomalyBuildupEventArgs evt);
     public delegate void AnomalyThresholdEvent(Context ctx, AnomalyThresholdEventArgs evt);
     public delegate void AnomalyTriggeredEvent(Context ctx, AnomalyTriggeredEventArgs evt);
+    public delegate void EtherVeilActivatedEvent(Context ctx, EtherVeilEventArgs evt);
+    public delegate void EtherVeilDeactivatedEvent(Context ctx, EtherVeilEventArgs evt);
     
     public List<ActionExecutedEvent> OnActionExecuted { get; } = [];
     public List<AftershockEvent> OnAftershock { get; } = [];
     public List<AnomalyBuildupEvent> OnAnomalyBuildup { get; } = [];
     public List<AnomalyThresholdEvent> OnAnomalyThreshold { get; } = [];
     public List<AnomalyTriggeredEvent> OnAnomalyTriggered { get; } = [];
+    public List<EtherVeilActivatedEvent> OnEtherVeilActivated { get; } = [];
+    public List<EtherVeilDeactivatedEvent> OnEtherVeilDeactivated { get; } = [];
 
     public void ActionExecuted(Context ctx, ActionExecutedEventArgs e) {
         foreach (var actionExecutedEvent in OnActionExecuted) {
@@ -36,6 +42,16 @@ public sealed class EventBus {
     public void AnomalyTriggered(Context ctx, AnomalyTriggeredEventArgs e) {
         foreach (var anomalyTriggeredEvent in OnAnomalyTriggered) {
             anomalyTriggeredEvent(ctx, e);
+        }
+    }
+    public void EtherVeilActivated(Context ctx, EtherVeilEventArgs evt) {
+        foreach (var etherVeilActivatedEvent in OnEtherVeilActivated) {
+            etherVeilActivatedEvent(ctx, evt);
+        }
+    }
+    public void EtherVeilDeactivated(Context ctx, EtherVeilEventArgs evt) {
+        foreach (var etherVeilDeactivatedEvent in OnEtherVeilDeactivated) {
+            etherVeilDeactivatedEvent(ctx, evt);
         }
     }
 }

--- a/InterknotCalculator.Core/Classes/Weapons/CloudcleaveRadiance.cs
+++ b/InterknotCalculator.Core/Classes/Weapons/CloudcleaveRadiance.cs
@@ -1,0 +1,26 @@
+using InterknotCalculator.Core.Enums;
+
+namespace InterknotCalculator.Core.Classes.Weapons;
+
+public class CloudcleaveRadiance : Weapon {
+    public CloudcleaveRadiance() : base(WeaponId.CloudcleaveRadiance) {
+        Speciality = Speciality.Attack;
+        Rarity = Rarity.S;
+        MainStat = new(Affix.Atk, 743);
+        SecondaryStat = new(Affix.CritDamage, 0.48);
+
+        Passive = [new(Affix.PhysicalResPen, 0.2)];
+    }
+
+    public override void RegisterHooks(Context ctx) {
+        ctx.Events.OnEtherVeilActivated.Add((c, e) => {
+            c.MainAgent.BonusStats[Affix.DmgBonus] += 0.25;
+            c.MainAgent.BonusStats[Affix.CritDamage] += 0.25;
+        });
+        
+        ctx.Events.OnEtherVeilDeactivated.Add((c, e) => {
+            c.MainAgent.BonusStats[Affix.DmgBonus] -= 0.25;
+            c.MainAgent.BonusStats[Affix.CritDamage] -= 0.25;
+        });
+    }
+}

--- a/InterknotCalculator.Core/Classes/Weapons/HalfSugarBunny.cs
+++ b/InterknotCalculator.Core/Classes/Weapons/HalfSugarBunny.cs
@@ -1,0 +1,30 @@
+using InterknotCalculator.Core.Enums;
+
+namespace InterknotCalculator.Core.Classes.Weapons;
+
+public class HalfSugarBunny : Weapon {
+    public HalfSugarBunny() : base(WeaponId.HalfSugarBunny) {
+        Speciality = Speciality.Defense;
+        Rarity = Rarity.S;
+        MainStat = new(Affix.Atk, 713);
+        SecondaryStat = new(Affix.HpRatio, 0.3);
+        ExternalBonus = [
+            new(Affix.AtkRatio, 0.1),
+            new(Affix.HpRatio, 0.1)
+        ];
+    }
+
+    private bool EtherVeilBonusActive { get; set; } = false;
+    
+    public override void RegisterHooks(Context ctx) {
+        ctx.Events.OnEtherVeilActivated.Add((c, veil) => {
+            if (EtherVeilBonusActive) return;
+
+            foreach (var (_, agent) in ctx.Team) {
+                agent.BonusStats[Affix.CritDamage] += 0.3;
+            }
+            
+            EtherVeilBonusActive = true;
+        });
+    }
+}

--- a/InterknotCalculator.Core/Classes/Weapons/Thoughtbop.cs
+++ b/InterknotCalculator.Core/Classes/Weapons/Thoughtbop.cs
@@ -1,0 +1,13 @@
+using InterknotCalculator.Core.Enums;
+
+namespace InterknotCalculator.Core.Classes.Weapons;
+
+public class Thoughtbop : Weapon {
+    public Thoughtbop() : base(WeaponId.Thoughtbop) {
+        Speciality = Speciality.Support;
+        Rarity = Rarity.S;
+        MainStat = new(Affix.Atk, 713);
+        SecondaryStat = new(Affix.EnergyRegenRatio, 0.6);
+        ExternalBonus = [new(Affix.DmgBonus, 0.125 * 2), new(Affix.CombatAtkRatio, 0.1)];
+    }
+}

--- a/InterknotCalculator.Core/Classes/Weapons/Weapon.cs
+++ b/InterknotCalculator.Core/Classes/Weapons/Weapon.cs
@@ -16,4 +16,6 @@ public abstract class Weapon(uint id) {
     public Stat[] ExternalBonus { get; init; } = [];
 
     public virtual void ApplyPassive(Agent agent) { }
+    
+    public virtual void RegisterHooks(Context ctx) { }
 }

--- a/InterknotCalculator.Core/Classes/Weapons/YesterdayCalls.cs
+++ b/InterknotCalculator.Core/Classes/Weapons/YesterdayCalls.cs
@@ -1,0 +1,15 @@
+using InterknotCalculator.Core.Classes.Agents;
+using InterknotCalculator.Core.Enums;
+
+namespace InterknotCalculator.Core.Classes.Weapons;
+
+public class YesterdayCalls : Weapon {
+    public YesterdayCalls() : base(WeaponId.YesterdayCalls) {
+        Speciality = Speciality.Stun;
+        Rarity = Rarity.S;
+        MainStat = new(Affix.Atk, 713);
+        SecondaryStat = new(Affix.CritRate, 0.24);
+        Passive = [new(Affix.DazeBonus, 0.27)];
+        ExternalBonus = [new(Affix.CritDamage, 0.3)];
+    }
+}

--- a/InterknotCalculator.Core/Enums/Faction.cs
+++ b/InterknotCalculator.Core/Enums/Faction.cs
@@ -17,5 +17,6 @@ public enum Faction {
     YunkuiSummit = 1 << 11,
     SpookShack = 1 << 12,
     KrampusComplianceAuthority = 1 << 13,
+    AngelsOfDelusion = 1 << 14,
     NewEriduDefenseForce = SilverSquad | ObolSquad | LyreSquad
 }

--- a/InterknotCalculator.Core/Enums/SkillTag.cs
+++ b/InterknotCalculator.Core/Enums/SkillTag.cs
@@ -2,7 +2,7 @@ namespace InterknotCalculator.Core.Enums;
 
 public enum SkillTag {
     BasicAtk, Dash, Counter, 
-    QuickAssist, DefensiveAssist, EvasiveAssist, FollowUpAssist,
+    Entry, QuickAssist, DefensiveAssist, EvasiveAssist, FollowUpAssist,
     Special, ExSpecial, Chain, Ultimate,
   
     AttributeAnomaly,

--- a/InterknotCalculator.Core/Enums/SkillTag.cs
+++ b/InterknotCalculator.Core/Enums/SkillTag.cs
@@ -1,6 +1,8 @@
 namespace InterknotCalculator.Core.Enums;
 
 public enum SkillTag {
+    DirectHit,
+    
     BasicAtk, Dash, Counter, 
     Entry, QuickAssist, DefensiveAssist, EvasiveAssist, FollowUpAssist,
     Special, ExSpecial, Chain, Ultimate,

--- a/InterknotCalculator.Core/Interfaces/IEtherVeilAgent.cs
+++ b/InterknotCalculator.Core/Interfaces/IEtherVeilAgent.cs
@@ -1,0 +1,7 @@
+using InterknotCalculator.Core.Classes.EtherVeils;
+
+namespace InterknotCalculator.Core.Interfaces;
+
+public interface IEtherVeilAgent<out T> where T : EtherVeil {
+    T EtherVeil { get; }
+}

--- a/InterknotCalculator.Test/Agents/AgentTests.cs
+++ b/InterknotCalculator.Test/Agents/AgentTests.cs
@@ -18,7 +18,7 @@ public abstract class AgentsTest {
 
     protected void PrintActions(IEnumerable<AgentAction> actions, double total) {
         foreach (var action in actions) {
-            Console.WriteLine($"{GetAgentName(action.AgentId), -12}{action.Name, -38}{action.Tag, -24}{action.Damage.ToString(CultureInfo.InvariantCulture)}");
+            Console.WriteLine($"{GetAgentName(action.AgentId), -16}{action.Name, -48}{action.Tag, -24}{action.Damage.ToString(CultureInfo.InvariantCulture)}");
         }
         Console.WriteLine($"Total: {total.ToString(CultureInfo.InvariantCulture)}");
     }

--- a/InterknotCalculator.Test/Agents/EllenTest.cs
+++ b/InterknotCalculator.Test/Agents/EllenTest.cs
@@ -121,8 +121,8 @@ public class EllenM6Tests : AgentsTest {
             new() {
                 SetId = DriveDiscSetId.WoodpeckerElectro,
                 Rarity = Rarity.S,
-                Stats = [Affix.Hp, Affix.Atk, Affix.CritDamage, Affix.CritRate, Affix.HpRatio],
-                Levels = [15, 1, 3, 2, 2]
+                Stats = [Affix.Hp, Affix.AnomalyProficiency, Affix.CritDamage, Affix.CritRate, Affix.AtkRatio],
+                Levels = [15, 3, 2, 2, 2]
             },
             new() {
                 SetId = DriveDiscSetId.WoodpeckerElectro,
@@ -139,8 +139,8 @@ public class EllenM6Tests : AgentsTest {
             new() {
                 SetId = DriveDiscSetId.WoodpeckerElectro,
                 Rarity = Rarity.S,
-                Stats = [Affix.CritDamage, Affix.DefRatio, Affix.AtkRatio, Affix.Pen, Affix.CritRate],
-                Levels = [15, 1, 2, 2, 3]
+                Stats = [Affix.CritDamage, Affix.AtkRatio, Affix.Atk, Affix.HpRatio, Affix.CritRate],
+                Levels = [15, 3, 2, 2, 1]
             },
             new() {
                 SetId = DriveDiscSetId.PolarMetal,
@@ -156,7 +156,7 @@ public class EllenM6Tests : AgentsTest {
             },
         ],
         Mindscape = 6,
-        Team = [new(AgentId.Lycaon)],
+        Team = [],//[new(AgentId.Lycaon)],
         StunBonus = 1.5,
         Rotation = [
             "avalanche",

--- a/InterknotCalculator.Test/Agents/SunnaTest.cs
+++ b/InterknotCalculator.Test/Agents/SunnaTest.cs
@@ -8,7 +8,7 @@ namespace InterknotCalculator.Test.Agents;
 [TestFixture]
 public class SunnaTest : AgentsTest {
     [Test]
-    public void CatsGazeAttackerTest() {
+    public void CatsGaze_AttackerTest() {
         var context = new Context();
         
         var ellen = new Ellen();
@@ -50,4 +50,51 @@ public class SunnaTest : AgentsTest {
         PrintActions(context.Actions, context.Actions.Sum(a => a.AgentId == ellen.Id ? a.Damage : 0));
     }
     
+    [Test]
+    public void CatsGazeTwoActivationCyclesWithNoClawSharpenersTest() {
+        var context = new Context();
+
+        var ellen = new Ellen();
+        ellen.RegisterHooks(context);
+        var sunna = new Sunna();
+        sunna.RegisterHooks(context);
+
+        context.Team.Add(ellen.Id, ellen);
+        context.Team.Add(sunna.Id, sunna);
+        context.MainAgentId = ellen.Id;
+
+        // Using "naughty_cat_spotted" instead of "special_photography_technique"
+        // to activate Cat's Gaze here, since the latter also reactivates
+        // the Ether Veil, which grants Claw Sharpeners and would defeat
+        // the "no remaining Claw Sharpeners" premise of this test
+
+        // Cycle 1: Activate Cat's Gaze
+        context.Actions.AddRange(sunna.GetActionDamage(context,
+            new(SkillTag.BasicAtk, "naughty_cat_spotted")));
+        context.ProcessActionsQueue();
+
+        // Let it fire and fully expire, since no Claw Sharpeners
+        // are available to reapply it (the default enemy is stunned,
+        // so the cooldown is fully consumed on this single action)
+        context.Actions.AddRange(ellen.GetActionDamage(context,
+            new(SkillTag.BasicAtk, "saw_teeth_trimming")));
+        context.ProcessActionsQueue();
+        
+        // Cycle 2: Reactivate Cat's Gaze after it has already expired once
+        context.Actions.AddRange(sunna.GetActionDamage(context,
+            new(SkillTag.BasicAtk, "naughty_cat_spotted")));
+        context.ProcessActionsQueue();
+
+        context.Actions.AddRange(ellen.GetActionDamage(context,
+            new(SkillTag.BasicAtk, "saw_teeth_trimming")));
+        context.ProcessActionsQueue();
+
+        var catsGazeActivations = context.Actions
+            .Count(action => action.Name == "cat's_gaze");
+
+        // Cat's Gaze must trigger once per cycle, twice in total
+        Assert.That(catsGazeActivations, Is.EqualTo(2));
+
+        PrintActions(context.Actions, context.Actions.Sum(a => a.AgentId == ellen.Id ? a.Damage : 0));
+    }
 }

--- a/InterknotCalculator.Test/Agents/SunnaTest.cs
+++ b/InterknotCalculator.Test/Agents/SunnaTest.cs
@@ -1,0 +1,53 @@
+using InterknotCalculator.Core.Classes;
+using InterknotCalculator.Core.Classes.Agents;
+using InterknotCalculator.Core.Classes.Server;
+using InterknotCalculator.Core.Enums;
+
+namespace InterknotCalculator.Test.Agents;
+
+[TestFixture]
+public class SunnaTest : AgentsTest {
+    [Test]
+    public void CatsGazeAttackerTest() {
+        var context = new Context();
+        
+        var ellen = new Ellen();
+        ellen.RegisterHooks(context);
+        var sunna = new Sunna();
+        sunna.RegisterHooks(context);
+        
+        context.Team.Add(ellen.Id, ellen);
+        context.Team.Add(sunna.Id, sunna);
+        context.MainAgentId = ellen.Id;
+
+        // context.Enemy.StunMultiplier = 1; // un-stun enemy
+        
+        context.Actions.AddRange(sunna.GetActionDamage(context, 
+                new(SkillTag.ExSpecial, "special_photography_technique")));
+        
+        context.ProcessActionsQueue();
+        
+        context.Actions.AddRange(ellen.GetActionDamage(context, 
+                new(SkillTag.BasicAtk, "saw_teeth_trimming")));
+        context.ProcessActionsQueue();
+        
+        context.Actions.AddRange(ellen.GetActionDamage(context, 
+                new(SkillTag.BasicAtk, "saw_teeth_trimming", 1)));
+        context.ProcessActionsQueue();
+        
+        context.Actions.AddRange(ellen.GetActionDamage(context, 
+                new(SkillTag.BasicAtk, "saw_teeth_trimming", 2)));
+        context.ProcessActionsQueue();
+        
+        context.Actions.AddRange(ellen.GetActionDamage(context, 
+            new(SkillTag.BasicAtk, "saw_teeth_trimming")));
+        context.ProcessActionsQueue();
+        
+        Assert.That(context.Actions.Count, Is.AtLeast(4));
+        Assert.That(context.Actions, Has.Some
+            .Matches<AgentAction>(action => action.Name == "cat's_gaze"));
+        
+        PrintActions(context.Actions, context.Actions.Sum(a => a.AgentId == ellen.Id ? a.Damage : 0));
+    }
+    
+}

--- a/InterknotCalculator.Test/Agents/YeShunguangTests.cs
+++ b/InterknotCalculator.Test/Agents/YeShunguangTests.cs
@@ -1,6 +1,4 @@
 using InterknotCalculator.Core.Classes;
-using InterknotCalculator.Core.Classes.Agents;
-using InterknotCalculator.Core.Classes.Enemies;
 using InterknotCalculator.Core.Classes.Server;
 using InterknotCalculator.Core.Enums;
 
@@ -8,6 +6,15 @@ namespace InterknotCalculator.Test.Agents;
 
 [TestFixture]
 public class YeShunguangTests : AgentsTest {
+    private static string[] Combo { get; } = [
+        "enlightened_mind_sunderlight 1",
+        "enlightened_mind_sunderlight 2",
+        "enlightened_mind_sunderlight_annihilation 2",
+        "enlightened_mind_sunderlight_maximum",
+        "enlightened_mind_soaring_light",
+        "enlightened_mind_skyward_ascent",
+    ];
+    
     private static string[] EntryRotation { get; } = [
         $"{AgentId.Sunna}.special_photography_technique",
         $"{AgentId.Zhao}.burst_of_frost",
@@ -16,27 +23,57 @@ public class YeShunguangTests : AgentsTest {
         "illuminating_darkness",
             
         // combo 1
-        "enlightened_mind_sunderlight 1",
-        "enlightened_mind_sunderlight 2",
-        "enlightened_mind_sunderlight_annihilation 2",
-        "enlightened_mind_sunderlight_maximum",
-        "enlightened_mind_soaring_light",
-        "enlightened_mind_skyward_ascent",
+        ..Combo,
             
         // combo 2
-        "enlightened_mind_sunderlight 1",
-        "enlightened_mind_sunderlight 2",
-        "enlightened_mind_sunderlight_annihilation 2",
-        "enlightened_mind_sunderlight_maximum",
-        "enlightened_mind_soaring_light",
-        "enlightened_mind_skyward_ascent",
+        ..Combo,
             
         // finisher
         "enlightened_mind_return_to_dust"
     ];
     
     public static string[] SixComboRotation { get; } = [
-        $"{AgentId.Dialyn}."
+        $"{AgentId.Sunna}.special_photography_technique",
+        
+        $"{AgentId.Dialyn}.rock",
+        $"{AgentId.Dialyn}.scissors",
+        $"{AgentId.Dialyn}.paper",
+        
+        // give her ult
+        $"{AgentId.Dialyn}.get_lost",
+        "chasing_storms",
+        
+        // combo 1
+        ..Combo,
+        // combo 2
+        ..Combo,
+        
+        // finisher
+        "enlightened_mind_return_to_dust",
+        
+        $"{AgentId.Sunna}.special_photography_technique",
+        
+        // enter racist mode
+        "illuminating_darkness",
+            
+        // combo 1
+        ..Combo,
+        // combo 2
+        ..Combo,
+        
+        // finisher
+        "enlightened_mind_return_to_dust",
+        
+        // ult
+        "chasing_storms",
+            
+        // combo 1
+        ..Combo,
+        // combo 2
+        ..Combo,
+        
+        // finisher
+        "cleaving_heavens"
     ];
     
     private CalcRequest YeShunguang { get; } = new() {
@@ -81,11 +118,12 @@ public class YeShunguangTests : AgentsTest {
             }
         ],
         Team = [
-            new(AgentId.Zhao, WeaponId.HalfSugarBunny, DriveDiscSetId.BunnyInWonderland), 
+            // new(AgentId.Zhao, WeaponId.HalfSugarBunny, DriveDiscSetId.BunnyInWonderland), 
+            new(AgentId.Dialyn, WeaponId.YesterdayCalls, DriveDiscSetId.KingOfTheSummit),
             new(AgentId.Sunna, WeaponId.Thoughtbop, DriveDiscSetId.MoonlightLullaby)
         ],
         StunBonus = 1,
-        Rotation = EntryRotation
+        Rotation = SixComboRotation, // EntryRotation
     };
     
     [Test]

--- a/InterknotCalculator.Test/Agents/YeShunguangTests.cs
+++ b/InterknotCalculator.Test/Agents/YeShunguangTests.cs
@@ -8,7 +8,7 @@ namespace InterknotCalculator.Test.Agents;
 
 [TestFixture]
 public class YeShunguangTests : AgentsTest {
-    private string[] EntryRotation { get; } = [
+    private static string[] EntryRotation { get; } = [
         $"{AgentId.Sunna}.special_photography_technique",
         $"{AgentId.Zhao}.burst_of_frost",
             
@@ -35,7 +35,7 @@ public class YeShunguangTests : AgentsTest {
         "enlightened_mind_return_to_dust"
     ];
     
-    public string[] SixComboRotation { get; } = [
+    public static string[] SixComboRotation { get; } = [
         $"{AgentId.Dialyn}."
     ];
     
@@ -85,9 +85,7 @@ public class YeShunguangTests : AgentsTest {
             new(AgentId.Sunna, WeaponId.Thoughtbop, DriveDiscSetId.MoonlightLullaby)
         ],
         StunBonus = 1,
-        Rotation = [
-            
-        ]
+        Rotation = EntryRotation
     };
     
     [Test]

--- a/InterknotCalculator.Test/Agents/YeShunguangTests.cs
+++ b/InterknotCalculator.Test/Agents/YeShunguangTests.cs
@@ -117,18 +117,39 @@ public class YeShunguangTests : AgentsTest {
                 Levels = [15, 2, 2, 3, 1]
             }
         ],
-        Team = [
-            // new(AgentId.Zhao, WeaponId.HalfSugarBunny, DriveDiscSetId.BunnyInWonderland), 
-            new(AgentId.Dialyn, WeaponId.YesterdayCalls, DriveDiscSetId.KingOfTheSummit),
-            new(AgentId.Sunna, WeaponId.Thoughtbop, DriveDiscSetId.MoonlightLullaby)
-        ],
+        Team = [],
         StunBonus = 1,
-        Rotation = SixComboRotation, // EntryRotation
+        Rotation = []
     };
     
     [Test]
-    public void YeShunguangTest() {
-        var result = Calculator.Calculate(YeShunguang);
+    public void YeShunguangEntryRotationTest() {
+        var request = YeShunguang with {
+            Team = [
+                new(AgentId.Zhao, WeaponId.HalfSugarBunny, DriveDiscSetId.BunnyInWonderland),
+                new(AgentId.Sunna, WeaponId.Thoughtbop, DriveDiscSetId.MoonlightLullaby)
+            ],
+            Rotation = EntryRotation
+        };
+        var result = Calculator.Calculate(request);
+        
+        Assert.That(result.PerAction, Is.Not.Empty);
+        
+        Console.WriteLine($"Total Anomaly triggers: {result.PerAction.Count(action => action.Tag == SkillTag.AttributeAnomaly)}");
+        PrintActions(result.PerAction, result.Total);
+        Console.WriteLine($"\nEnemy anomaly\n{string.Join('\n', result.Enemy.AnomalyBuildup)}");
+    }
+    
+    [Test]
+    public void YeShunguangSixComboRotationTest() {
+        var request = YeShunguang with {
+            Team = [
+                new(AgentId.Dialyn, WeaponId.YesterdayCalls, DriveDiscSetId.KingOfTheSummit),
+                new(AgentId.Sunna, WeaponId.Thoughtbop, DriveDiscSetId.MoonlightLullaby)
+            ],
+            Rotation = SixComboRotation
+        };
+        var result = Calculator.Calculate(request);
         
         Assert.That(result.PerAction, Is.Not.Empty);
         

--- a/InterknotCalculator.Test/Agents/YeShunguangTests.cs
+++ b/InterknotCalculator.Test/Agents/YeShunguangTests.cs
@@ -1,0 +1,103 @@
+using InterknotCalculator.Core.Classes;
+using InterknotCalculator.Core.Classes.Agents;
+using InterknotCalculator.Core.Classes.Enemies;
+using InterknotCalculator.Core.Classes.Server;
+using InterknotCalculator.Core.Enums;
+
+namespace InterknotCalculator.Test.Agents;
+
+[TestFixture]
+public class YeShunguangTests : AgentsTest {
+    private string[] EntryRotation { get; } = [
+        $"{AgentId.Sunna}.special_photography_technique",
+        $"{AgentId.Zhao}.burst_of_frost",
+            
+        // enter racist mode
+        "illuminating_darkness",
+            
+        // combo 1
+        "enlightened_mind_sunderlight 1",
+        "enlightened_mind_sunderlight 2",
+        "enlightened_mind_sunderlight_annihilation 2",
+        "enlightened_mind_sunderlight_maximum",
+        "enlightened_mind_soaring_light",
+        "enlightened_mind_skyward_ascent",
+            
+        // combo 2
+        "enlightened_mind_sunderlight 1",
+        "enlightened_mind_sunderlight 2",
+        "enlightened_mind_sunderlight_annihilation 2",
+        "enlightened_mind_sunderlight_maximum",
+        "enlightened_mind_soaring_light",
+        "enlightened_mind_skyward_ascent",
+            
+        // finisher
+        "enlightened_mind_return_to_dust"
+    ];
+    
+    public string[] SixComboRotation { get; } = [
+        $"{AgentId.Dialyn}."
+    ];
+    
+    private CalcRequest YeShunguang { get; } = new() {
+        AgentId = AgentId.YeShunguang,
+        WeaponId = WeaponId.CloudcleaveRadiance,
+        Discs = [
+            new() {
+                SetId = DriveDiscSetId.BranchBladeSong,
+                Rarity = Rarity.S,
+                Stats = [Affix.Hp, Affix.CritDamage, Affix.DefRatio, Affix.CritRate, Affix.Def],
+                Levels = [15, 1, 2, 4, 1]
+            },
+            new() {
+                SetId = DriveDiscSetId.WhiteWaterBallad,
+                Rarity = Rarity.S,
+                Stats = [Affix.Atk, Affix.CritRate, Affix.CritDamage, Affix.AnomalyProficiency, Affix.DefRatio],
+                Levels = [15, 1, 3, 1, 3]
+            },
+            new() {
+                SetId = DriveDiscSetId.WhiteWaterBallad,
+                Rarity = Rarity.S,
+                Stats = [Affix.Def, Affix.AtkRatio, Affix.CritDamage, Affix.Atk, Affix.CritRate],
+                Levels = [15, 1, 3, 2, 2]
+            },
+            new() {
+                SetId = DriveDiscSetId.WhiteWaterBallad,
+                Rarity = Rarity.S,
+                Stats = [Affix.CritDamage, Affix.CritRate, Affix.Def, Affix.Atk, Affix.Pen],
+                Levels = [15, 3, 2, 1, 3]
+            },
+            new() {
+                SetId = DriveDiscSetId.WhiteWaterBallad,
+                Rarity = Rarity.S,
+                Stats = [Affix.AtkRatio, Affix.CritDamage, Affix.Pen, Affix.CritRate, Affix.Hp],
+                Levels = [15, 2, 1, 2, 3]
+            },
+            new() {
+                SetId = DriveDiscSetId.BranchBladeSong,
+                Rarity = Rarity.S,
+                Stats = [Affix.AtkRatio, Affix.Hp, Affix.CritDamage, Affix.Atk, Affix.CritRate],
+                Levels = [15, 2, 2, 3, 1]
+            }
+        ],
+        Team = [
+            new(AgentId.Zhao, WeaponId.HalfSugarBunny, DriveDiscSetId.BunnyInWonderland), 
+            new(AgentId.Sunna, WeaponId.Thoughtbop, DriveDiscSetId.MoonlightLullaby)
+        ],
+        StunBonus = 1,
+        Rotation = [
+            
+        ]
+    };
+    
+    [Test]
+    public void YeShunguangTest() {
+        var result = Calculator.Calculate(YeShunguang);
+        
+        Assert.That(result.PerAction, Is.Not.Empty);
+        
+        Console.WriteLine($"Total Anomaly triggers: {result.PerAction.Count(action => action.Tag == SkillTag.AttributeAnomaly)}");
+        PrintActions(result.PerAction, result.Total);
+        Console.WriteLine($"\nEnemy anomaly\n{string.Join('\n', result.Enemy.AnomalyBuildup)}");
+    }
+}

--- a/InterknotCalculator.Test/EtherVeilTests.cs
+++ b/InterknotCalculator.Test/EtherVeilTests.cs
@@ -1,0 +1,104 @@
+using InterknotCalculator.Core.Classes;
+using InterknotCalculator.Core.Classes.Agents;
+using InterknotCalculator.Core.Classes.EtherVeils;
+using InterknotCalculator.Core.Enums;
+
+namespace InterknotCalculator.Test;
+
+[TestFixture]
+public class EtherVeilTests {
+    private Context Context { get; set; }
+    
+    [SetUp]
+    public void SetUp() {
+        Context = new();
+    }
+
+    [Test]
+    public async Task EtherVeilActivated() {
+        var zhao = new Zhao();
+        zhao.RegisterHooks(Context);
+        
+        var task = new TaskCompletionSource<EtherVeil>();
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        await using var registration = cts.Token.Register(() => task.TrySetException(new TimeoutException()));
+        
+        Context.Events.OnEtherVeilActivated.Add((_, e) => {
+           Assert.That(e.Agent, Is.EqualTo(zhao));
+           
+           task.TrySetResult(e.EtherVeil);
+        });
+        
+        var action = zhao.GetActionDamage(Context, new(SkillTag.Entry, "burst_of_frost"));
+        
+        Assert.That(action, Has.Exactly(1).Items);
+
+        var veil = await task.Task;
+        
+        Assert.That(veil, Is.Not.Null);
+        Assert.That(veil, Is.TypeOf<Wellspring>());
+    }
+
+    [Test]
+    public async Task MultipleVeilsActivated() {
+        var zhao = new Zhao();
+        zhao.RegisterHooks(Context);
+        
+        var sunna = new Sunna();
+        sunna.RegisterHooks(Context);
+        
+        var task = new TaskCompletionSource<EtherVeil[]>();
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        await using var registration = cts.Token.Register(() => task.TrySetException(new TimeoutException()));
+
+        Context.Events.OnEtherVeilActivated.Add((c, e) => {
+            if (c.GetEtherVeil<Wellspring>() is { } wellspring && 
+                c.GetEtherVeil<DelusionReprise>() is { } reprise) {
+                task.SetResult([wellspring, reprise]);
+            }
+        });
+        
+        var action = zhao.GetActionDamage(Context, new(SkillTag.Entry, "burst_of_frost"));
+        Assert.That(action, Has.Exactly(1).Items);
+        action = sunna.GetActionDamage(Context, new(SkillTag.ExSpecial, "special_photography_technique"));
+        Assert.That(action, Has.Exactly(1).Items);
+
+        var veils = await task.Task;
+        
+        Assert.That(veils, Has.Exactly(2).Items);
+        Assert.That(veils, Has.Exactly(1).TypeOf<Wellspring>());
+        Assert.That(veils, Has.Exactly(1).TypeOf<DelusionReprise>());
+    }
+
+    [Test]
+    public async Task EtherVeilAffectsStats() {
+        var sunna = new Sunna();
+        Context.Team.Add(sunna.Id, sunna);
+        sunna.RegisterHooks(Context);
+        
+        var task = new TaskCompletionSource<EtherVeil>();
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        await using var registration = cts.Token.Register(() => task.TrySetException(new TimeoutException()));
+        
+        Context.Events.OnEtherVeilActivated.Add((_, e) => {
+            Assert.That(e.Agent, Is.EqualTo(sunna));
+           
+            task.TrySetResult(e.EtherVeil);
+        });
+
+        var statsBefore = sunna.CollectStats();
+        
+        var action = sunna.GetActionDamage(Context, new(SkillTag.ExSpecial, "special_photography_technique"));
+        
+        Assert.That(action, Has.Exactly(1).Items);
+
+        var veil = await task.Task;
+        
+        Assert.That(veil, Is.Not.Null);
+        Assert.That(veil, Is.TypeOf<DelusionReprise>());
+        
+        var statsAfter = sunna.CollectStats();
+        
+        Assert.That(statsAfter[Affix.Atk], Is.EqualTo(statsBefore[Affix.Atk] + 50));
+    }
+}


### PR DESCRIPTION
Fixes [IKC-24](https://youtrack.interknot.space/issue/IKC-24)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Dialyn, Sunna, Ye Shunguang, and Zhao with complete abilities, passives, team effects, and combat mechanics.
  - Added Ether Veil activation, deactivation, stat effects, and event tracking.
  - Added Cold Blooded, Delusion Reprise, Verdict, and Wellspring Ether Veils.
  - Added Cloudcleave Radiance, Half Sugar Bunny, Thoughtbop, and Yesterday Calls weapons.
  - Added faction and skill tags for expanded team and combat interactions.

- **Bug Fixes**
  - Updated Ellen’s passive to apply critical damage bonuses to additional abilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->